### PR TITLE
[DNM] Add codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @hashicorp/packer
+* @marinsalinas @Hakujou @outscale-mgo


### PR DESCRIPTION
Do not merge. 
The codeowners file is currently managed by terraform and the change will be overwritten. 